### PR TITLE
Add hashtag and created_at columns for users table

### DIFF
--- a/modules/mode/fdfmode_classic.js
+++ b/modules/mode/fdfmode_classic.js
@@ -32,16 +32,16 @@ class Fdfmode_classic extends Manager_state {
      * Database init
      * =====================
      * Save users nickname and other information
-     * 
+     *
      */
     init_db() {
         let self = this;
         this.db.serialize(function() {
-            self.db.run("CREATE TABLE IF NOT EXISTS users (id INTEGER PRIMARY KEY AUTOINCREMENT, account TEXT, mode TEXT, username TEXT, photo_url TEXT, type_action TEXT)");
+            self.db.run("CREATE TABLE IF NOT EXISTS users (id INTEGER PRIMARY KEY AUTOINCREMENT, account TEXT, mode TEXT, username TEXT, photo_url TEXT, hashtag TEXT, type_action TEXT, inserted_on datetime default current_timestamp)");
         });
 
         this.db_fdf.serialize(function() {
-            self.db_fdf.run("CREATE TABLE IF NOT EXISTS fdf (id INTEGER PRIMARY KEY AUTOINCREMENT, account TEXT, username TEXT, photo_url TEXT, type_fdf TEXT)");
+            self.db_fdf.run("CREATE TABLE IF NOT EXISTS fdf (id INTEGER PRIMARY KEY AUTOINCREMENT, account TEXT, username TEXT, photo_url TEXT, hashtag TEXT, type_fdf TEXT, inserted_on datetime default current_timestamp)");
         });
     }
 
@@ -49,7 +49,7 @@ class Fdfmode_classic extends Manager_state {
      * Get photo url from cache
      * =====================
      * @return {string} url
-     * 
+     *
      */
     get_photo_url() {
         let photo_url = "";
@@ -67,10 +67,10 @@ class Fdfmode_classic extends Manager_state {
      *
      */
     async fdf_open_hashtagpage() {
-        let hashtag_tag = this.utils.get_random_hash_tag();
-        this.log.info(`current hashtag ${hashtag_tag}`);
+        this.hashtag_tag = this.utils.get_random_hash_tag();
+        this.log.info(`current hashtag ${this.hashtag_tag}`);
         try {
-            await this.bot.goto("https://www.instagram.com/explore/tags/" + hashtag_tag + "/");
+            await this.bot.goto("https://www.instagram.com/explore/tags/" + this.hashtag_tag + "/");
         } catch (err) {
             this.log.error(`goto ${err}`);
         }
@@ -174,7 +174,7 @@ class Fdfmode_classic extends Manager_state {
                 this.log.info("button text before click: " + button_before_click);
                 if (this.photo_liked[this.photo_current] > 1) {
                     this.log.warning("followed previously");
-                    this.db.run("INSERT INTO users (account, mode, username, photo_url, type_action) VALUES (?, ?, ?, ?, ?)", this.config.instagram_username, this.LOG_NAME, username, this.photo_current, "followed previously");
+                    this.db.run("INSERT INTO users (account, mode, username, photo_url, hashtag, type_action) VALUES (?, ?, ?, ?, ?, ?)?)", this.config.instagram_username, this.LOG_NAME, username, this.photo_current, this.hashtag_tag, "followed previously");
                 } else {
                     await button.click();
 
@@ -186,8 +186,8 @@ class Fdfmode_classic extends Manager_state {
 
                     if (button_after_click != button_before_click) {
                         this.log.info("follow");
-                        this.db.run("INSERT INTO users (account, mode, username, photo_url, type_action) VALUES (?, ?, ?, ?, ?)", this.config.instagram_username, this.LOG_NAME, username, this.photo_current, "follow");
-                        this.db_fdf.run("INSERT INTO fdf (account, username, photo_url, type_fdf) VALUES (?, ?, ?, ?)", this.config.instagram_username, username, this.photo_current, "follow");
+                        this.db.run("INSERT INTO users (account, mode, username, photo_url, hashtag, type_action) VALUES (?, ?, ?, ?, ?, ?)(?, ?, ?, ?, ?)", this.config.instagram_username, this.LOG_NAME, username, this.photo_current, this.hashtag_tag, "follow");
+                        this.db_fdf.run("INSERT INTO fdf (account, username, photo_url, hashtag, type_fdf) VALUES (?, ?, ?, ?)", this.config.instagram_username, username, this.photo_current, this.hashtag_tag, "follow");
                     } else {
                         this.log.warning("not follow");
                     }
@@ -200,7 +200,7 @@ class Fdfmode_classic extends Manager_state {
                 }
 
                 this.log.warning("follow error");
-                this.db.run("INSERT INTO users (account, mode, username, photo_url, type_action) VALUES (?, ?, ?, ?, ?)", this.config.instagram_username, this.LOG_NAME, username, this.photo_current, "follow error");
+                this.db.run("INSERT INTO users (account, mode, username, photo_url, hashtag, type_action) VALUES (?, ?, ?, ?, ?, ?) ?, ?, ?)", this.config.instagram_username, this.LOG_NAME, username, this.photo_current, this.hashtag_tag, "follow error");
                 this.emit(this.STATE_EVENTS.CHANGE_STATUS, this.STATE.ERROR);
             }
 
@@ -261,7 +261,7 @@ class Fdfmode_classic extends Manager_state {
 
             if (this.photo_liked[this.photo_current] > 1) {
                 this.log.warning("followed previously");
-                this.db.run("INSERT INTO users (account, mode, username, photo_url, type_action) VALUES (?, ?, ?, ?, ?)", this.config.instagram_username, this.LOG_NAME, username, this.photo_current, "defollowed previously");
+                this.db.run("INSERT INTO users (account, mode, username, photo_url, hashtag, type_action) VALUES (?, ?, ?, ?, ?, ?)", this.config.instagram_username, this.LOG_NAME, username, this.photo_current, this.hashtag_tag, "defollowed previously");
             } else {
                 await button.click();
 
@@ -280,7 +280,7 @@ class Fdfmode_classic extends Manager_state {
 
                 if (button_after_click != button_before_click) {
                     this.log.info("defollow");
-                    this.db.run("INSERT INTO users (account, mode, username, photo_url, type_action) VALUES (?, ?, ?, ?, ?)", this.config.instagram_username, this.LOG_NAME, username, this.photo_current, "defollow");
+                    this.db.run("INSERT INTO users (account, mode, username, photo_url, hashtag, type_action) VALUES (?, ?, ?, ?, ?, ?)", this.config.instagram_username, this.LOG_NAME, username, this.photo_current, this.hashtag_tag, "defollow");
                     this.db_fdf.run("UPDATE fdf SET type_fdf = ? WHERE account = ? AND username = ?", "defollow", this.config.instagram_username, username);
                 } else {
                     this.log.warning("not defollow, try at next rotation");
@@ -293,7 +293,7 @@ class Fdfmode_classic extends Manager_state {
             }
 
             this.log.warning("defollow error");
-            this.db.run("INSERT INTO users (account, mode, username, photo_url, type_action) VALUES (?, ?, ?, ?, ?)", this.config.instagram_username, this.LOG_NAME, username, this.photo_current, "defollow error");
+            this.db.run("INSERT INTO users (account, mode, username, photo_url, hashtag, type_action) VALUES (?, ?, ?, ?, ?, ?)", this.config.instagram_username, this.LOG_NAME, username, this.photo_current, this.hashtag_tag, "defollow error");
             this.emit(this.STATE_EVENTS.CHANGE_STATUS, this.STATE.ERROR);
         }
 
@@ -337,7 +337,7 @@ class Fdfmode_classic extends Manager_state {
                         this.log.info("defollow user from photo: " + users[ir].photo_url);
                         await this.goto_user_for_defollow(users[ir].photo_url);
                         await this.utils.sleep(this.utils.random_interval(4, 8));
-                        await this.fdf_click_defollow();   
+                        await this.fdf_click_defollow();
                     }
                 }
 

--- a/modules/mode/fdfmode_classic.js
+++ b/modules/mode/fdfmode_classic.js
@@ -174,7 +174,7 @@ class Fdfmode_classic extends Manager_state {
                 this.log.info("button text before click: " + button_before_click);
                 if (this.photo_liked[this.photo_current] > 1) {
                     this.log.warning("followed previously");
-                    this.db.run("INSERT INTO users (account, mode, username, photo_url, hashtag, type_action) VALUES (?, ?, ?, ?, ?, ?)?)", this.config.instagram_username, this.LOG_NAME, username, this.photo_current, this.hashtag_tag, "followed previously");
+                    this.db.run("INSERT INTO users (account, mode, username, photo_url, hashtag, type_action) VALUES (?, ?, ?, ?, ?, ?)", this.config.instagram_username, this.LOG_NAME, username, this.photo_current, this.hashtag_tag, "followed previously");
                 } else {
                     await button.click();
 
@@ -186,8 +186,8 @@ class Fdfmode_classic extends Manager_state {
 
                     if (button_after_click != button_before_click) {
                         this.log.info("follow");
-                        this.db.run("INSERT INTO users (account, mode, username, photo_url, hashtag, type_action) VALUES (?, ?, ?, ?, ?, ?)(?, ?, ?, ?, ?)", this.config.instagram_username, this.LOG_NAME, username, this.photo_current, this.hashtag_tag, "follow");
-                        this.db_fdf.run("INSERT INTO fdf (account, username, photo_url, hashtag, type_fdf) VALUES (?, ?, ?, ?)", this.config.instagram_username, username, this.photo_current, this.hashtag_tag, "follow");
+                        this.db.run("INSERT INTO users (account, mode, username, photo_url, hashtag, type_action) VALUES (?, ?, ?, ?, ?, ?)", this.config.instagram_username, this.LOG_NAME, username, this.photo_current, this.hashtag_tag, "follow");
+                        this.db_fdf.run("INSERT INTO fdf (account, username, photo_url, hashtag, type_fdf) VALUES (?, ?, ?, ?, ?)", this.config.instagram_username, username, this.photo_current, this.hashtag_tag, "follow");
                     } else {
                         this.log.warning("not follow");
                     }
@@ -200,7 +200,7 @@ class Fdfmode_classic extends Manager_state {
                 }
 
                 this.log.warning("follow error");
-                this.db.run("INSERT INTO users (account, mode, username, photo_url, hashtag, type_action) VALUES (?, ?, ?, ?, ?, ?) ?, ?, ?)", this.config.instagram_username, this.LOG_NAME, username, this.photo_current, this.hashtag_tag, "follow error");
+                this.db.run("INSERT INTO users (account, mode, username, photo_url, hashtag, type_action) VALUES (?, ?, ?, ?, ?, ?)", this.config.instagram_username, this.LOG_NAME, username, this.photo_current, this.hashtag_tag, "follow error");
                 this.emit(this.STATE_EVENTS.CHANGE_STATUS, this.STATE.ERROR);
             }
 

--- a/modules/mode/fdfmode_classic.js
+++ b/modules/mode/fdfmode_classic.js
@@ -37,11 +37,11 @@ class Fdfmode_classic extends Manager_state {
     init_db() {
         let self = this;
         this.db.serialize(function() {
-            self.db.run("CREATE TABLE IF NOT EXISTS users (id INTEGER PRIMARY KEY AUTOINCREMENT, account TEXT, mode TEXT, username TEXT, photo_url TEXT, hashtag TEXT, type_action TEXT, inserted_on datetime default current_timestamp)");
+            self.db.run("CREATE TABLE IF NOT EXISTS users (id INTEGER PRIMARY KEY AUTOINCREMENT, account TEXT, mode TEXT, username TEXT, photo_url TEXT, hashtag TEXT, type_action TEXT, inserted_at DATETIME DEFAULT CURRENT_TIMESTAMP)");
         });
 
         this.db_fdf.serialize(function() {
-            self.db_fdf.run("CREATE TABLE IF NOT EXISTS fdf (id INTEGER PRIMARY KEY AUTOINCREMENT, account TEXT, username TEXT, photo_url TEXT, hashtag TEXT, type_fdf TEXT, inserted_on datetime default current_timestamp)");
+            self.db_fdf.run("CREATE TABLE IF NOT EXISTS fdf (id INTEGER PRIMARY KEY AUTOINCREMENT, account TEXT, username TEXT, photo_url TEXT, hashtag TEXT, type_fdf TEXT, inserted_at DATETIME DEFAULT CURRENT_TIMESTAMP)");
         });
     }
 

--- a/modules/mode/likemode_realistic.js
+++ b/modules/mode/likemode_realistic.js
@@ -7,7 +7,7 @@
  * @license:    This code and contributions have 'GNU General Public License v3'
  * @version:    0.1
  * @changelog:  0.1 initial release
- * 
+ *
  */
 const Manager_state = require("../common/state").Manager_state;
 class Likemode_realistic extends Manager_state {
@@ -31,12 +31,12 @@ class Likemode_realistic extends Manager_state {
      * Database init
      * =====================
      * Save users nickname and other information
-     * 
+     *
      */
     init_db() {
         let self = this;
         this.db.serialize(function() {
-            self.db.run("CREATE TABLE IF NOT EXISTS users (id INTEGER PRIMARY KEY AUTOINCREMENT, account TEXT, mode TEXT, username TEXT, photo_url TEXT, type_action TEXT)");
+            self.db.run("CREATE TABLE IF NOT EXISTS users (id INTEGER PRIMARY KEY AUTOINCREMENT, account TEXT, mode TEXT, username TEXT, photo_url TEXT, hashtag TEXT, type_action TEXT, inserted_on datetime default current_timestamp)");
         });
     }
 
@@ -44,7 +44,7 @@ class Likemode_realistic extends Manager_state {
      * Get photo url from cache
      * =====================
      * @return {string} url
-     * 
+     *
      */
     get_photo_url() {
         let photo_url = "";
@@ -61,10 +61,10 @@ class Likemode_realistic extends Manager_state {
      *
      */
     async like_open_hashtagpage() {
-        let hashtag_tag = this.utils.get_random_hash_tag();
-        this.log.info(`current hashtag ${hashtag_tag}`);
+        this.hashtag_tag = this.utils.get_random_hash_tag();
+        this.log.info(`current hashtag ${this.hashtag_tag}`);
         try {
-            await this.bot.goto("https://www.instagram.com/explore/tags/" + hashtag_tag + "/");
+            await this.bot.goto("https://www.instagram.com/explore/tags/" + this.hashtag_tag + "/");
         } catch (err) {
             this.log.error(`goto ${err}`);
         }
@@ -165,12 +165,12 @@ class Likemode_realistic extends Manager_state {
             let button = await this.bot.$("main article:nth-child(1) section:nth-child(1) button:nth-child(1)");
 
             if (this.photo_liked[this.photo_current] > 1) {
-                this.log.warning("</3 liked previously");
-                this.db.run("INSERT INTO users (account, mode, username, photo_url, type_action) VALUES (?, ?, ?, ?, ?)", this.config.instagram_username, this.LOG_NAME, username, this.photo_current, "</3 liked previously");
+                this.log.warning("</3 Skipped, liked previously");
+                this.db.run("INSERT INTO users (account, mode, username, photo_url, hashtag, type_action) VALUES (?, ?, ?, ?, ?, ?)", this.config.instagram_username, this.LOG_NAME, username, this.photo_current, this.hashtag_tag, "skipped");
             } else {
                 await button.click();
-                this.log.info("<3");
-                this.db.run("INSERT INTO users (account, mode, username, photo_url, type_action) VALUES (?, ?, ?, ?, ?)", this.config.instagram_username, this.LOG_NAME, username, this.photo_current, "</3");
+                this.log.info("<3 Liked");
+                this.db.run("INSERT INTO users (account, mode, username, photo_url, hashtag, type_action) VALUES (?, ?, ?, ?, ?, ?)", this.config.instagram_username, this.LOG_NAME, username, this.photo_current, this.hashtag_tag, "liked");
             }
             this.emit(this.STATE_EVENTS.CHANGE_STATUS, this.STATE.OK);
         } catch (err) {
@@ -179,7 +179,7 @@ class Likemode_realistic extends Manager_state {
             }
 
             this.log.warning("</3");
-            this.db.run("INSERT INTO users (account, mode, username, photo_url, type_action) VALUES (?, ?, ?, ?, ?)", this.config.instagram_username, this.LOG_NAME, username, this.photo_current, "</3 error_catch");
+            this.db.run("INSERT INTO users (account, mode, username, photo_url, hashtag, type_action) VALUES (?, ?, ?, ?, ?, ?)", this.config.instagram_username, this.LOG_NAME, username, this.photo_current, this.hashtag_tag, "error");
             this.emit(this.STATE_EVENTS.CHANGE_STATUS, this.STATE.ERROR);
         }
 
@@ -245,5 +245,5 @@ class Likemode_realistic extends Manager_state {
 }
 
 module.exports = (bot, config, utils, db) => {
-    return new Likemode_realistic(bot, config, utils, db); 
+    return new Likemode_realistic(bot, config, utils, db);
 };

--- a/modules/mode/likemode_realistic.js
+++ b/modules/mode/likemode_realistic.js
@@ -36,7 +36,7 @@ class Likemode_realistic extends Manager_state {
     init_db() {
         let self = this;
         this.db.serialize(function() {
-            self.db.run("CREATE TABLE IF NOT EXISTS users (id INTEGER PRIMARY KEY AUTOINCREMENT, account TEXT, mode TEXT, username TEXT, photo_url TEXT, hashtag TEXT, type_action TEXT, inserted_on datetime default current_timestamp)");
+            self.db.run("CREATE TABLE IF NOT EXISTS users (id INTEGER PRIMARY KEY AUTOINCREMENT, account TEXT, mode TEXT, username TEXT, photo_url TEXT, hashtag TEXT, type_action TEXT, inserted_at DATETIME DEFAULT CURRENT_TIMESTAMP)");
         });
     }
 


### PR DESCRIPTION
###

- Add `hashtag` and `created_at` fields for users and pdf tables
- Display more explicit output text

### What could be done

Instead of have an table for each mode, use global table `users` and `posts` :

```
users
    id: INTEGER PRIMARY KEY AUTOINCREMENT,
    account: TEXT,
    username: TEXT,
    mode: TEXT,
    url: TEXT,
    hashtag: TEXT,
    created_at: DATETIME DEFAULT CURRENT_TIMESTAMP

posts
    id: INTEGER PRIMARY KEY AUTOINCREMENT,
    account: TEXT,
    username: TEXT,
    mode: TEXT,
    url: TEXT,
    hashtag: TEXT,
    created_at: DATETIME DEFAULT CURRENT_TIMESTAMP
```

